### PR TITLE
Update sqlx to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ atmosphere-core = { version = "=0.3.0", path = "atmosphere-core" }
 atmosphere-macros = { version = "=0.3.0", path = "atmosphere-macros" }
 async-trait = "0.1"
 lazy_static = "1"
-sqlx = { version = "0.7", features = ["chrono"] }
+sqlx = { version = "0.8", features = ["chrono"] }
 thiserror = "1"
 
 [package]
@@ -47,7 +47,7 @@ postgres = ["atmosphere-core/postgres", "atmosphere-macros/postgres"]
 sqlite = ["atmosphere-core/sqlite", "atmosphere-macros/sqlite"]
 
 [dev-dependencies]
-sqlx = { version = "0.7", features = [
+sqlx = { version = "0.8", features = [
     "runtime-tokio-rustls",
     "any",
     "sqlite",

--- a/atmosphere-core/src/bind.rs
+++ b/atmosphere-core/src/bind.rs
@@ -22,7 +22,7 @@
 
 use crate::{Column, Result, Table};
 use miette::Diagnostic;
-use sqlx::database::HasArguments;
+use sqlx::database::Database;
 use sqlx::query::QueryAs;
 use sqlx::{Encode, QueryBuilder, Type};
 use thiserror::Error;
@@ -40,7 +40,7 @@ pub enum BindError {
     Unknown(&'static str),
 }
 
-type Query<'q, DB> = sqlx::query::Query<'q, DB, <DB as HasArguments<'q>>::Arguments>;
+type Query<'q, DB> = sqlx::query::Query<'q, DB, <DB as Database>::Arguments<'q>>;
 
 /// Trait for dynamic binding of values.
 ///
@@ -66,7 +66,7 @@ impl<'q> Bindable<'q> for Query<'q, crate::Driver> {
 }
 
 impl<'q, E> Bindable<'q>
-    for QueryAs<'q, crate::Driver, E, <crate::Driver as HasArguments<'q>>::Arguments>
+    for QueryAs<'q, crate::Driver, E, <crate::Driver as Database>::Arguments<'q>>
 {
     fn dyn_bind<T: 'q + Send + Encode<'q, crate::Driver> + Type<crate::Driver>>(
         self,

--- a/atmosphere-core/src/rel.rs
+++ b/atmosphere-core/src/rel.rs
@@ -5,7 +5,7 @@
 //! relationships in a database using SQLx.
 
 use async_trait::async_trait;
-use sqlx::database::HasArguments;
+use sqlx::database::Database;
 use sqlx::{Executor, IntoArguments};
 
 use crate::bind::Bind;
@@ -31,8 +31,7 @@ where
     async fn resolve<'e, E>(&self, executor: E) -> Result<Other>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let Query { builder, .. } = sql::select::<Other>();
 
@@ -65,8 +64,7 @@ where
     async fn resolve<'e, E>(&self, executor: E) -> Result<Vec<Other>>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let Query { builder, .. } = sql::select_by::<Other>(Other::FOREIGN_KEY.as_col());
 
@@ -87,8 +85,7 @@ where
     async fn resolve_by<'e, E>(executor: E, pk: &Self::PrimaryKey) -> Result<Vec<Other>>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let Query { builder, .. } = sql::select_by::<Other>(Other::FOREIGN_KEY.as_col());
 
@@ -108,8 +105,7 @@ where
     ) -> Result<<crate::Driver as sqlx::Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let Query { builder, .. } = sql::delete_by::<Other>(Other::FOREIGN_KEY.as_col());
 

--- a/atmosphere-core/src/schema/create.rs
+++ b/atmosphere-core/src/schema/create.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use sqlx::{database::HasArguments, Executor, IntoArguments};
+use sqlx::{database::Database, Executor, IntoArguments};
 
 /// Trait for creating rows in a database.
 ///
@@ -25,8 +25,7 @@ pub trait Create: Table + Bind + Hooks + Sync + 'static {
     ) -> Result<<crate::Driver as sqlx::Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send;
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send;
 }
 
 #[async_trait]
@@ -40,8 +39,7 @@ where
     ) -> Result<<crate::Driver as sqlx::Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let query = crate::runtime::sql::insert::<T>();
 

--- a/atmosphere-core/src/schema/delete.rs
+++ b/atmosphere-core/src/schema/delete.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use sqlx::{database::HasArguments, Database, Executor, IntoArguments};
+use sqlx::{Database, Executor, IntoArguments};
 
 /// Trait for deleting rows from a database.
 ///
@@ -25,8 +25,7 @@ pub trait Delete: Table + Bind + Hooks + Send + Sync + Unpin + 'static {
     ) -> Result<<crate::Driver as Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send;
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send;
 
     /// Deletes a row from the database based on its primary key. This method is particularly
     /// useful for deleting entities when only the primary key is available.
@@ -36,8 +35,7 @@ pub trait Delete: Table + Bind + Hooks + Send + Sync + Unpin + 'static {
     ) -> Result<<crate::Driver as Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send;
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send;
 }
 
 #[async_trait]
@@ -51,8 +49,7 @@ where
     ) -> Result<<crate::Driver as Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let query = crate::runtime::sql::delete::<T>();
 
@@ -94,8 +91,7 @@ where
     ) -> Result<<crate::Driver as Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let query = crate::runtime::sql::delete::<T>();
 

--- a/atmosphere-core/src/schema/read.rs
+++ b/atmosphere-core/src/schema/read.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use sqlx::{database::HasArguments, Executor, IntoArguments};
+use sqlx::{database::Database, Executor, IntoArguments};
 
 /// Trait for reading rows from a database.
 ///
@@ -22,8 +22,7 @@ pub trait Read: Table + Bind + Hooks + Send + Sync + Unpin + 'static {
     async fn read<'e, E>(executor: E, pk: &Self::PrimaryKey) -> Result<Self>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send;
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send;
 
     /// Finds and retrieves a row by its primary key. This method constructs a query to fetch
     /// a single row based on the primary key, executes it, and returns the result, optionally
@@ -31,16 +30,14 @@ pub trait Read: Table + Bind + Hooks + Send + Sync + Unpin + 'static {
     async fn find<'e, E>(executor: E, pk: &Self::PrimaryKey) -> Result<Option<Self>>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send;
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send;
 
     /// Retrieves all rows from the table. This method is useful for fetching the complete
     /// dataset of a table, executing a query to return all rows, and applying hooks as needed.
     async fn read_all<'e, E>(executor: E) -> Result<Vec<Self>>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send;
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send;
 
     /// Reloads the current entity from the database. This method is designed to update the entity
     /// instance with the latest data from the database, ensuring that it reflects the current
@@ -48,8 +45,7 @@ pub trait Read: Table + Bind + Hooks + Send + Sync + Unpin + 'static {
     async fn reload<'e, E>(&mut self, executor: E) -> Result<()>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send;
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send;
 }
 
 #[async_trait]
@@ -60,8 +56,7 @@ where
     async fn read<'e, E>(executor: E, pk: &Self::PrimaryKey) -> Result<Self>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let query = crate::runtime::sql::select::<T>();
 
@@ -94,8 +89,7 @@ where
     async fn find<'e, E>(executor: E, pk: &Self::PrimaryKey) -> Result<Option<Self>>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let query = crate::runtime::sql::select::<T>();
 
@@ -128,8 +122,7 @@ where
     async fn read_all<'e, E>(executor: E) -> Result<Vec<Self>>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let query = crate::runtime::sql::select_all::<T>();
 
@@ -156,8 +149,7 @@ where
     async fn reload<'e, E>(&mut self, executor: E) -> Result<()>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let query = crate::runtime::sql::select_by::<T>(T::PRIMARY_KEY.as_col());
 

--- a/atmosphere-core/src/schema/update.rs
+++ b/atmosphere-core/src/schema/update.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use sqlx::{database::HasArguments, Database, Executor, IntoArguments};
+use sqlx::{Database, Executor, IntoArguments};
 
 /// Update rows in a database.
 ///
@@ -25,8 +25,7 @@ pub trait Update: Table + Bind + Hooks + Send + Sync + Unpin + 'static {
     ) -> Result<<crate::Driver as Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send;
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send;
 
     /// Similar to `update`, but either updates an existing row or inserts a new one if it does not
     /// exist, depending on the primary key's presence and uniqueness.
@@ -36,8 +35,7 @@ pub trait Update: Table + Bind + Hooks + Send + Sync + Unpin + 'static {
     ) -> Result<<crate::Driver as Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send;
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send;
 }
 
 #[async_trait]
@@ -51,8 +49,7 @@ where
     ) -> Result<<crate::Driver as Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let query = crate::runtime::sql::update::<T>();
 
@@ -89,8 +86,7 @@ where
     ) -> Result<<crate::Driver as Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
-        for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
-            IntoArguments<'q, crate::Driver> + Send,
+        for<'q> <crate::Driver as Database>::Arguments<'q>: IntoArguments<'q, crate::Driver> + Send,
     {
         let query = crate::runtime::sql::upsert::<T>();
 

--- a/atmosphere-macros/src/derive/queries/unique.rs
+++ b/atmosphere-macros/src/derive/queries/unique.rs
@@ -42,7 +42,7 @@ pub fn queries(table: &Table) -> TokenStream {
                 ) -> ::atmosphere::Result<Option<#ident>>
                 where
                     E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::Database>::Arguments<'q>:
                         ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send
                 {
                     use ::atmosphere::{
@@ -70,7 +70,7 @@ pub fn queries(table: &Table) -> TokenStream {
                 ) -> ::atmosphere::Result<<::atmosphere::Driver as ::atmosphere::sqlx::Database>::QueryResult>
                 where
                     E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::Database>::Arguments<'q>:
                         ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send
                 {
                     use ::atmosphere::{

--- a/atmosphere-macros/src/derive/relationships.rs
+++ b/atmosphere-macros/src/derive/relationships.rs
@@ -43,7 +43,7 @@ pub fn relationships(table: &Table) -> TokenStream {
                 ) -> ::atmosphere::Result<#other>
                 where
                     E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::Database>::Arguments<'q>:
                         ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
                     <#ident as ::atmosphere::rel::RefersTo<#other>>::resolve(&self, executor).await
                 }
@@ -55,7 +55,7 @@ pub fn relationships(table: &Table) -> TokenStream {
                 ) -> ::atmosphere::Result<Vec<#ident>>
                 where
                     E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::Database>::Arguments<'q>:
                         ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
                     <#other as ::atmosphere::rel::ReferredBy<#ident>>::resolve_by(executor, pk).await
                 }
@@ -69,7 +69,7 @@ pub fn relationships(table: &Table) -> TokenStream {
                 ) -> ::atmosphere::Result<Vec<#ident>>
                 where
                     E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::Database>::Arguments<'q>:
                         ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
                     <#other as ::atmosphere::rel::ReferredBy<#ident>>::resolve(&self, executor).await
                 }
@@ -80,7 +80,7 @@ pub fn relationships(table: &Table) -> TokenStream {
                 ) -> ::atmosphere::Result<<::atmosphere::Driver as ::atmosphere::sqlx::Database>::QueryResult>
                 where
                     E: ::atmosphere::sqlx::Executor<'e, Database = ::atmosphere::Driver>,
-                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::HasArguments<'q>>::Arguments:
+                    for<'q> <::atmosphere::Driver as ::atmosphere::sqlx::database::Database>::Arguments<'q>:
                         ::atmosphere::sqlx::IntoArguments<'q, ::atmosphere::Driver> + Send {
                     <#other as ::atmosphere::rel::ReferredBy<#ident>>::delete_all(&self, executor).await
                 }


### PR DESCRIPTION
`sqlx` 0.8 has [quite a few breaking changes](https://github.com/launchbadge/sqlx/blob/main/CHANGELOG.md#080---2024-07-22).

As far as we are concerned, the only compile-time breaking change is that the generic trait `HasArguments` has been replaced with a generic associated type in https://github.com/launchbadge/sqlx/pull/2973, however this should be a no-op (the trait was only useful before GAT were introduced).

There are a few runtime breaking changes (eg. https://github.com/launchbadge/sqlx/pull/2736 or https://github.com/launchbadge/sqlx/pull/3064), but they seem very specific. Users should review the release notes above to check if anything apply to them in particular when upgrading.