### PR TITLE
fix!: derive `Schema` using `table` attribute macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ system.
 ```rust
 use atmosphere::prelude::*;
 
-#[derive(Schema)]
 #[table(schema = "public", name = "user")]
 struct User {
     #[sql(pk)]
@@ -44,7 +43,6 @@ struct User {
     email: String,
 }
 
-#[derive(Schema)]
 #[table(schema = "public", name = "post")]
 struct Post {
     #[sql(pk)]
@@ -103,7 +101,6 @@ trait.
 
 ### Alpha Release
 - [x] Advanced SQL Trait System (`Table`, `Column`, `Relation` ..)
-- [x] Derive Macro (`Schema`)
 - [x] SQL Field Attributes (`#[sql(pk)]`, `#[sql(fk -> Model)]` and so on)
 - [x] SQL Query Generation
 - [x] Automated Integration Testing
@@ -140,13 +137,11 @@ trait.
 
 ## Functionalities
 
-Given a `struct Model` that derives its atmosphere schema using
-`#[derive(Schema)]` and `#[table]`:
+Given a `struct Model` that derives its atmosphere schema using `#[table]`:
 
 ```rust
 use atmosphere::prelude::*;
 
-#[derive(Schema)]
 #[table(schema = "public", name = "model")]
 struct Model {
     #[sql(pk)]
@@ -197,7 +192,6 @@ Given that a model contains fields are marked as a foreign key / point to
 another `atmosphere::Table` atmosphere – for example:
 
 ```rust
-#[derive(Schema)]
 #[table(schema = "public", name = "submodel")]
 struct Submodel {
     #[sql(pk)]

--- a/atmosphere-macros/src/schema/table.rs
+++ b/atmosphere-macros/src/schema/table.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
 use syn::parse::{Parse, ParseStream};
-use syn::{Error, Fields, Generics, Ident, LitStr, Token, Visibility};
+use syn::spanned::Spanned as _;
+use syn::{Error, Fields, Ident, LitStr, Token};
 
 use crate::hooks::Hooks;
 use crate::schema::column::{Column, DataColumn, TimestampColumn};
@@ -55,13 +56,6 @@ impl Parse for TableId {
 
 #[derive(Clone, Debug)]
 pub struct Table {
-    // TODO(flrn):
-    //  confirm what the fields `vis` and `generics` were
-    //  intended for; remove them if they are not needed
-    #[allow(dead_code)]
-    pub vis: Visibility,
-    #[allow(dead_code)]
-    pub generics: Generics,
     pub ident: Ident,
 
     pub id: TableId,
@@ -74,19 +68,12 @@ pub struct Table {
     pub hooks: Hooks,
 }
 
-impl Parse for Table {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let item: syn::ItemStruct = input.parse()?;
-
-        let id: TableId = item
-            .attrs
-            .iter()
-            .find(|attr| attr.path().is_ident("table"))
-            .ok_or(syn::Error::new(
-                input.span(),
-                "You need to use the `#[table]` attribute if you want to derive `Schema`",
-            ))?
-            .parse_args()?;
+impl Table {
+    pub fn parse_struct(
+        item: &syn::ItemStruct,
+        table_args: proc_macro::TokenStream,
+    ) -> syn::Result<Self> {
+        let id: TableId = syn::parse(table_args)?;
 
         let hooks: Hooks = {
             let attr = item.attrs.iter().find(|attr| attr.path().is_ident("hooks"));
@@ -98,19 +85,20 @@ impl Parse for Table {
             }
         };
 
-        let ident = item.ident;
+        let ident = &item.ident;
 
-        let fields = match item.fields {
+        let fields = match &item.fields {
             Fields::Named(n) => n,
             Fields::Unnamed(_) | Fields::Unit => {
                 return Err(Error::new(
                     ident.span(),
-                    format!("{ident} must use named fields in order to derive `Schema`"),
+                    format!("{ident} must use named fields in order to be used with `table`"),
                 ));
             }
         };
 
         let columns = fields
+            .clone()
             .named
             .into_iter()
             .map(Column::try_from)
@@ -125,7 +113,7 @@ impl Parse for Table {
 
             if primary_keys.len() > 1 {
                 return Err(Error::new(
-                    input.span(),
+                    item.span(),
                     format!(
                         "{ident} declares more than one column as its primary key – only one is allowed"
                     ),
@@ -133,10 +121,8 @@ impl Parse for Table {
             }
 
             primary_keys.into_iter().next().ok_or(Error::new(
-                input.span(),
-                format!(
-                    "{ident} must declare one field as its primary key (using `#[primary_key]`"
-                ),
+                item.span(),
+                format!("{ident} must declare one field as its primary key (using `#[sql(pk)]`"),
             ))?
         };
 
@@ -159,9 +145,7 @@ impl Parse for Table {
             .collect();
 
         Ok(Self {
-            vis: item.vis,
-            generics: item.generics,
-            ident,
+            ident: ident.clone(),
             id,
             primary_key,
             foreign_keys,

--- a/docs/src/getting-started/queries.md
+++ b/docs/src/getting-started/queries.md
@@ -1,7 +1,7 @@
 # Queries
 
 When using Atmosphere, you have two options for writing queries. Once you
-derive `Schema` on your entities, it gives you the ability to use querying
+annotate your entities with `table`, it gives you the ability to use querying
 traits that Atmosphere comes with. However, you can at any point reach down
 and write your queries in raw SQL, the way you would if you used `sqlx`
 directly.
@@ -16,7 +16,7 @@ Atmosphere creates traits that allow for simple operations on the tables.
 # extern crate sqlx;
 # extern crate tokio;
 # use atmosphere::prelude::*;
-# #[derive(Schema, Debug, PartialEq)]
+# #[derive(Debug, PartialEq)]
 # #[table(schema = "public", name = "user")]
 # struct User {
 #     #[sql(pk)]
@@ -25,7 +25,7 @@ Atmosphere creates traits that allow for simple operations on the tables.
 #     #[sql(unique)]
 #     email: String,
 # }
-# #[derive(Schema, Debug, PartialEq)]
+# #[derive(Debug, PartialEq)]
 # #[table(schema = "public", name = "post")]
 # struct Post {
 #     #[sql(pk)]

--- a/docs/src/getting-started/schema.md
+++ b/docs/src/getting-started/schema.md
@@ -1,8 +1,8 @@
 # Define your Schema
 
 To make use of Atmosphere, you must define your schema in a way that Atmosphere
-can understand it. To do so, you use Rust structs augmented with the [`Schema`]
-derive macro and some metadata which tells it how to map it to SQL.
+can understand it. To do so, you use Rust structs augmented with the [`table`]
+attribute macro and some metadata which tells it how to map it to SQL.
 
 Here is an example of what such a schema might look like if you are storing
 users and posts in a database.
@@ -12,7 +12,6 @@ users and posts in a database.
 # extern crate sqlx;
 use atmosphere::prelude::*;
 
-#[derive(Schema)]
 #[table(schema = "public", name = "user")]
 struct User {
     #[sql(pk)]
@@ -22,7 +21,6 @@ struct User {
     email: String,
 }
 
-#[derive(Schema)]
 #[table(schema = "public", name = "post")]
 struct Post {
     #[sql(pk)]
@@ -46,7 +44,6 @@ the appropriate keys on the `#[table]` annotation.
 # extern crate atmosphere;
 # extern crate sqlx;
 # use atmosphere::prelude::*;
-#[derive(Schema)]
 #[table(schema = "public", name = "users")]
 struct User {
     # #[sql(pk)]
@@ -62,4 +59,4 @@ struct User {
 Every struct member corresponds to one row of your backing table. Here you can
 use the `#[sql]` annotation to add metadata.
 
-[`Schema`]: https://docs.rs/atmosphere/latest/atmosphere/derive.Schema.html
+[`table`]: https://docs.rs/atmosphere/latest/atmosphere/attr.table.html

--- a/docs/src/traits/create.md
+++ b/docs/src/traits/create.md
@@ -1,14 +1,14 @@
 # Create
 
 The [`Create`] trait allows you to create new rows in your tables. Here is an example
-of how to create a user, given that you have derived its [`Schema`]:
+of how to create a user, given that you have it annotated with [`table`]:
 
 ```rust
 # extern crate atmosphere;
 # extern crate sqlx;
 # extern crate tokio;
 # use atmosphere::prelude::*;
-#[derive(Schema, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 #[table(schema = "public", name = "user")]
 struct User {
     #[sql(pk)]
@@ -34,5 +34,5 @@ user.create(&pool).await?;
 # fn main() {}
 ```
 
-[`Schema`]: https://docs.rs/atmosphere/latest/atmosphere/derive.Schema.html
+[`table`]: https://docs.rs/atmosphere/latest/atmosphere/attr.table.html
 [`Create`]: https://docs.rs/atmosphere/latest/atmosphere/trait.Create.html

--- a/docs/src/traits/delete.md
+++ b/docs/src/traits/delete.md
@@ -1,14 +1,15 @@
 # Delete
 
 The [`Delete`] trait allows you to read entities from rows in your table. Here is
-an example of how to create a user, given that you have derived its [`Schema`]:
+an example of how to create a user, given that you have it annotated with
+[`table`]:
 
 ```rust
 # extern crate atmosphere;
 # extern crate sqlx;
 # extern crate tokio;
 # use atmosphere::prelude::*;
-#[derive(Schema, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 #[table(schema = "public", name = "user")]
 struct User {
     #[sql(pk)]
@@ -35,5 +36,5 @@ User::delete_by(&pool, &4).await?;
 # fn main() {}
 ```
 
-[`Schema`]: https://docs.rs/atmosphere/latest/atmosphere/derive.Schema.html
+[`table`]: https://docs.rs/atmosphere/latest/atmosphere/attr.table.html
 [`Delete`]: https://docs.rs/atmosphere/latest/atmosphere/trait.Delete.html

--- a/docs/src/traits/index.md
+++ b/docs/src/traits/index.md
@@ -1,7 +1,7 @@
 # Traits
 
-Given that you have derived `Schema` for your entities, Atmosphere provides you
-with some traits for simple CRUD operations on your database. These make it
+Given that you have annotated your entities with `table`, Atmosphere provides
+you with some traits for simple CRUD operations on your database. These make it
 very straightforward to do simple operations, but keep in mind that you are
 always able to reach down and write raw SQL manually where it makes sense.
 

--- a/docs/src/traits/read.md
+++ b/docs/src/traits/read.md
@@ -1,14 +1,15 @@
 # Read
 
 The [`Read`] trait allows you to read entities from rows in your table. Here is
-an example of how to create a user, given that you have derived its [`Schema`]:
+an example of how to create a user, given that you have it annotated with
+[`table`]:
 
 ```rust
 # extern crate atmosphere;
 # extern crate sqlx;
 # extern crate tokio;
 # use atmosphere::prelude::*;
-#[derive(Schema, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 #[table(schema = "public", name = "user")]
 struct User {
     #[sql(pk)]
@@ -35,5 +36,5 @@ user.reload(&pool).await?;
 # fn main() {}
 ```
 
-[`Schema`]: https://docs.rs/atmosphere/latest/atmosphere/derive.Schema.html
+[`table`]: https://docs.rs/atmosphere/latest/atmosphere/attr.table.html
 [`Read`]: https://docs.rs/atmosphere/latest/atmosphere/trait.Read.html

--- a/docs/src/traits/update.md
+++ b/docs/src/traits/update.md
@@ -1,14 +1,15 @@
 # Update
 
 The [`Update`] trait allows you to read entities from rows in your table. Here is
-an example of how to create a user, given that you have derived its [`Schema`]:
+an example of how to create a user, given that you have it annotated with
+[`table`]:
 
 ```rust
 # extern crate atmosphere;
 # extern crate sqlx;
 # extern crate tokio;
 # use atmosphere::prelude::*;
-#[derive(Schema, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 #[table(schema = "public", name = "user")]
 struct User {
     #[sql(pk)]
@@ -34,5 +35,5 @@ user.update(&pool).await?;
 # fn main() {}
 ```
 
-[`Schema`]: https://docs.rs/atmosphere/latest/atmosphere/derive.Schema.html
+[`table`]: https://docs.rs/atmosphere/latest/atmosphere/attr.table.html
 [`Update`]: https://docs.rs/atmosphere/latest/atmosphere/trait.Update.html

--- a/examples/blog/main.rs
+++ b/examples/blog/main.rs
@@ -2,7 +2,7 @@ use atmosphere::prelude::*;
 
 use sqlx::types::chrono;
 
-#[derive(Schema, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[table(schema = "public", name = "user")]
 struct User {
     #[sql(pk)]
@@ -12,7 +12,7 @@ struct User {
     email: String,
 }
 
-#[derive(Schema, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[table(schema = "public", name = "post")]
 struct Post {
     #[sql(pk)]

--- a/examples/forest/main.rs
+++ b/examples/forest/main.rs
@@ -2,7 +2,7 @@ use atmosphere::prelude::*;
 
 use sqlx::types::chrono;
 
-#[derive(Schema, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[table(schema = "public", name = "forest")]
 struct Forest {
     #[sql(pk)]
@@ -15,7 +15,7 @@ struct Forest {
     created: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Schema, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[table(schema = "public", name = "tree")]
 struct Tree {
     #[sql(pk)]

--- a/tests/db/crud.rs
+++ b/tests/db/crud.rs
@@ -1,7 +1,7 @@
 use atmosphere::prelude::*;
 use atmosphere_core::Table;
 
-#[derive(Schema, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[table(name = "forest", schema = "public")]
 struct Forest {
     #[sql(pk)]
@@ -10,7 +10,7 @@ struct Forest {
     location: String,
 }
 
-#[derive(Schema, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 #[table(name = "tree", schema = "public")]
 struct Tree {
     #[sql(pk)]


### PR DESCRIPTION
While using this crate I encountered some errors when deriving `Schema`. It boils down to the way `#[table]` attribute (macro) is used (and parsed). The error that was reported by `rust-analyzer` was `"You need to use the '#[table]' attribute if you want to derive 'Schema'"`, even though the `#[table]` attribute was used. 

The problem seems to be in the order of running proc macros. Typically, derive macros use attributes and they indicate these in their definition, such as `#[proc_macro_derive(Schema, attributes(sql))]`. However, the `#[table]` macro needs to modify the struct it annotates, so derive macro with attributes is not sufficient in this case. 

Using attribute macro for `#[table]` is necessary to modify the fields of a struct, but then this strips the `#[table]` attribute away and `derive(Schema)` complains. If we leave it in place, compiler complains about unknown attribute, and if we specify it as part of the derive macro then the `#[table]` is interpreted as attribute (not macro!) and so the attribute macro(!) does not run. 

I thought of two possible solutions: 

* use `with_table(...)` attribute for `derive(Schema)`, and generate that attribute by `#[table(...)]` attribute macro. This solves the problem, but does not seem like intended way to do such manipulations. 
* generate derivations using the `#[table]` attribute macro alone. Since attribute macros can do everything derive macros can and more, we can take advantage of that and completely remove the need for `#[derive(Schema)]` annotation. 

I went with the second choice, as that seems like the standard and obvious way to implement this. Note that this is a breaking change, as the `Schema` derive macro is completely removed, and only `#[table]` attribute macro should be used (optionally with `hooks` macro, as before). 

Before putting in more work, I wanted to check with you if you would be fine with this change. If yes, I can further improve this PR if necessary (feedback would be helpful). 

BREAKING CHANGE: `Schema` derive macro is removed and made obsolete by the `table` attribute macro. 